### PR TITLE
Made internal function m_seedRand static

### DIFF
--- a/mtwister.c
+++ b/mtwister.c
@@ -15,7 +15,7 @@
 
 #include "mtwister.h"
 
-inline void m_seedRand(MTRand* rand, unsigned long seed) {
+inline static void m_seedRand(MTRand* rand, unsigned long seed) {
   /* set initial seeds to mt[STATE_VECTOR_LENGTH] using the generator
    * from Line 25 of Table 1 in: Donald Knuth, "The Art of Computer
    * Programming," Vol. 2 (2nd Ed.) pp.102.


### PR DESCRIPTION
`m_seedRand` is not a static function, despite only being used within `mtwister.c`; it's not even mentioned in the`mtwister.h` API header! For some reason (perhaps related to it being declared as an `inline` function), linking `mtwister.c` into a library would fail, until the `static` keyword was added, after which point it worked well again.

I suggest investigating into this a little ourselves so we may learn more about this kind of situation to deal with it in the future! I was also puzzled when I encountered the issue, and still am not sure about how declaring the function as 'static` fixed it!

Overall, though, I really like this little library, and I'm going to include it into a new project of mine as a statically-linked external dependency. :)

For context, here's the error `ld` prints out with the code before this edit:

```
ld: error: undefined symbol: m_seedRand
>>> referenced by mtwister.c:34 (../extlibs/esultanik_mtwister/mtwister.c:34)
>>>               extlibs_esultanik_mtwister_mtwister.c.o:(seedRand) in archive libmtwist.a
>>> referenced by mtwister.c:49 (../extlibs/esultanik_mtwister/mtwister.c:49)
>>>               extlibs_esultanik_mtwister_mtwister.c.o:(genRandLong) in archive libmtwist.a
collect2: error: ld returned 1 exit status
```